### PR TITLE
Proposed fix and test-case for stack-overflow during error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function parse(input) {
 	parser
 		.on('error', function (e) {
 			if (hasErr) {
-				parser.end();
+				// Calling parser.end() here can cause infinite loop if Sax raises another error.
 				return; // Already errored
 			}
 
@@ -203,7 +203,12 @@ function parse(input) {
 			if (_.isStream(input)) {
 				input.pipe(parser);
 			} else if (_.isString(input) || _.isBuffer(input)) {
-				parser.write(input).close();
+				try{
+					parser.write(input).close();
+				}
+				catch(err){
+					emitter.emit('error', err);
+				}
 			}
 			next();
 		})

--- a/test/data/medline-cancer.nbib
+++ b/test/data/medline-cancer.nbib
@@ -1,0 +1,1532 @@
+PMID- 27236861
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 2045-7634 (Electronic)
+IS  - 2045-7634 (Linking)
+DP  - 2016 May 28
+TI  - Prognostic value of preoperative von Willebrand factor plasma levels in patients 
+      with Glioblastoma.
+LID - 10.1002/cam4.747 [doi]
+AB  - Circulating biomarker for malignant gliomas could improve both differential
+      diagnosis and clinical management of brain tumor patients. Among all gliomas,
+      glioblastoma (GBM) is considered the most hypervascularized tumor with activation
+      of multiple proangiogenic signaling pathways that enhance tumor growth. To
+      investigate whether preoperative antigen plasma level of von Willebrand Factor
+      (VWF:Ag) might be possible marker for GBM onset, progression, and prognosis, we
+      retrospectively examined 57 patients with histological diagnosis for GBM and 23
+      meningiomas (MNGs), benign intracranial expansive lesions, enrolled as controls. 
+      Blood samples were collected from all the patients before tumor resection. Plasma
+      von Willebrand Factor (VWF):Ag levels were determined by using a latex
+      particle-enhanced immunoturbidimetric assay. The median levels of vWF:Ag were
+      significantly higher in GBMs than in meningiomas (MNGs) (183 vs. 133 IU/dL, P =
+      0.01). The cumulative 1-year survival was significantly shorter in patients with 
+      VWF:Ag levels >200 IU/dL than in those with levels <200 IU/dL and increased VWF
+      levels were associated with a threefold higher risk of death in GBM patients. Our
+      data suggest that VWF:Ag could be a circulating biomarker of disease malignancy, 
+      that could be considered, in association with other genetic and epigenetic
+      factors, currently available in the GBM management. Future studies should
+      investigate whether plasma VWF:Ag levels could also be used to monitor
+      therapeutic effects and whether it may have a prognostic value.
+CI  - (c) 2016 The Authors. Cancer Medicine published by John Wiley & Sons Ltd.
+FAU - Marfia, Giovanni
+AU  - Marfia G
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Navone, Stefania Elena
+AU  - Navone SE
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Fanizzi, Claudia
+AU  - Fanizzi C
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Tabano, Silvia
+AU  - Tabano S
+AD  - Division of Pathology, Department of Pathophysiology and Transplantation,
+      Fondazione IRCCS Ca' Granda Ospedale Maggiore Policlinico, University of Milan,
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Pesenti, Chiara
+AU  - Pesenti C
+AD  - Division of Pathology, Department of Pathophysiology and Transplantation,
+      Fondazione IRCCS Ca' Granda Ospedale Maggiore Policlinico, University of Milan,
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Abdel Hadi, Loubna
+AU  - Abdel Hadi L
+AD  - Department of Medical Biotechnology and Translational Medicine, LITA-Segrate,
+      University of Milan, via Fratelli Cervi, 93, MI Milan, Segrate, 20090, Italy.
+FAU - Franzini, Andrea
+AU  - Franzini A
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Caroli, Manuela
+AU  - Caroli M
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Miozzo, Monica
+AU  - Miozzo M
+AD  - Division of Pathology, Department of Pathophysiology and Transplantation,
+      Fondazione IRCCS Ca' Granda Ospedale Maggiore Policlinico, University of Milan,
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Riboni, Laura
+AU  - Riboni L
+AD  - Department of Medical Biotechnology and Translational Medicine, LITA-Segrate,
+      University of Milan, via Fratelli Cervi, 93, MI Milan, Segrate, 20090, Italy.
+FAU - Rampini, Paolo
+AU  - Rampini P
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+FAU - Campanella, Rolando
+AU  - Campanella R
+AD  - Laboratory of Experimental Neurosurgery and Cell Therapy, Neurosurgery Unit,
+      Fondazione IRCCS Ca' Granda, Ospedale Maggiore Policlinico, University of Milan, 
+      via F. Sforza, 35, Milan, 20122, Italy.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160528
+TA  - Cancer Med
+JT  - Cancer medicine
+JID - 101595310
+OTO - NOTNLM
+OT  - Angiogenesis
+OT  - Glioblastoma
+OT  - brain tumor
+OT  - glioma.
+OT  - vascular endothelial growth factor
+OT  - von Willebrand Factor
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/01/25 [received]
+PHST- 2016/03/24 [revised]
+PHST- 2016/04/02 [accepted]
+AID - 10.1002/cam4.747 [doi]
+PST - aheadofprint
+SO  - Cancer Med. 2016 May 28. doi: 10.1002/cam4.747.
+
+PMID- 27236850
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1769-6917 (Electronic)
+IS  - 0007-4551 (Linking)
+DP  - 2016 May 25
+TI  - Evaluating the influence of prophylactic central neck dissection on TNM staging
+      and the recurrence risk stratification of cN differentiated thyroid carcinoma.
+LID - S0007-4551(16)30041-8 [pii]
+LID - 10.1016/j.bulcan.2016.04.003 [doi]
+AB  - OBJECTIVE: The purpose of this study was to explore the risk factors that were
+      associated with central lymph node metastasis (CLNM) in patients with clinical
+      nodal negative differentiated thyroid carcinoma (cN0 DTC) after prophylactic
+      central neck dissection (pCND). The influence of pCND on TNM staging and
+      recurrence risk stratification (RRS) in patients with cN0 DTC was also evaluated 
+      in our study. METHODS: A total of 153 cN0 DTC patients in Guangdong general
+      hospital who underwent thyroidectomy with pCND from March 2014 to October 2014
+      were enrolled in this study. The relations of CLNM with clinicopathologic
+      characteristics of cN0 DTC were analyzed by univariate and multivariate logistic 
+      regression. The influence of pCND on migration of TNM staging and RRS in cN0 DTC 
+      was observed. RESULTS: In the present study, CLNM was found in 42.5% (65 of 153
+      cases) of patients with cN0 DTC. On univariate analysis, the age less than 45
+      years old, tumor size more than 2cm, pT staging, and a total number of central
+      lymph nodes dissected more than 3 were significantly associated with CLNM
+      (P<0.05); however, gender, tumors affecting both lobes, multifocality, capsular
+      invasion, and Hashimoto's thyroiditis were not related with CLNM (P>0.05). On
+      multivariate logistic regression, age<45 years (P=0.001) and a total number of
+      central lymph nodes dissected >3 (P=0.002) were significantly associated with
+      CLNM. Because of the identification of CLNM in the implementation of pCND, 15
+      (9.8%) of 153 cN0 DTC patients were upgraded in TNM staging; all these patients
+      were older than 45 years. Fifty-six patients (36.6%) developed higher RRS (from
+      low to intermediate) after pCND. CONCLUSIONS: For younger patients (age<45
+      years), careful preoperative assessment of the lymph node status must be done;
+      surgeons should consider this risk factor when deciding whether to perform pCND. 
+      Thorough lymphadenectomy in the implementation of pCND can avoid residual lymph
+      node metastasis and help to increase the incidence of CLNM. pCND can indentify
+      occult CLNM which allows more precise TNM staging (for patients with age>/=45
+      years) and RRS.
+CI  - Copyright (c) 2016 Societe Francaise du Cancer. Published by Elsevier Masson SAS.
+      All rights reserved.
+FAU - Lin, Xiaodong
+AU  - Lin X
+AD  - Guangdong general hospital, Guangdong academy of medical sciences, department of 
+      general surgery, 106, Zhong Shan second road, 510080 Guangzhou, Guangdong
+      Province, China.
+FAU - Chen, Xiaoyi
+AU  - Chen X
+AD  - Guangdong general hospital, Guangdong academy of medical sciences, department of 
+      general surgery, 106, Zhong Shan second road, 510080 Guangzhou, Guangdong
+      Province, China.
+FAU - Jiru, Yuan
+AU  - Jiru Y
+AD  - Guangdong general hospital, Guangdong academy of medical sciences, department of 
+      general surgery, 106, Zhong Shan second road, 510080 Guangzhou, Guangdong
+      Province, China.
+FAU - Du, Jialin
+AU  - Du J
+AD  - Guangdong general hospital, Guangdong academy of medical sciences, department of 
+      general surgery, 106, Zhong Shan second road, 510080 Guangzhou, Guangdong
+      Province, China.
+FAU - Zhao, Gang
+AU  - Zhao G
+AD  - Guangdong general hospital, Guangdong academy of medical sciences, department of 
+      general surgery, 106, Zhong Shan second road, 510080 Guangzhou, Guangdong
+      Province, China.
+FAU - Wu, Zeyu
+AU  - Wu Z
+AD  - Guangdong general hospital, Guangdong academy of medical sciences, department of 
+      general surgery, 106, Zhong Shan second road, 510080 Guangzhou, Guangdong
+      Province, China. Electronic address: wu.zeyu@hotmail.com.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160525
+TA  - Bull Cancer
+JT  - Bulletin du cancer
+JID - 0072416
+OTO - NOTNLM
+OT  - Central lymph node metastasis (CLNM)
+OT  - Differentiated thyroid carcinoma (DTC)
+OT  - Prophylactic central neck dissection (pCND)
+OT  - Recurrence risk stratification (RRS)
+OT  - Risk factors
+OT  - TNM staging
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2015/10/17 [received]
+PHST- 2016/01/30 [revised]
+PHST- 2016/04/14 [accepted]
+AID - S0007-4551(16)30041-8 [pii]
+AID - 10.1016/j.bulcan.2016.04.003 [doi]
+PST - aheadofprint
+SO  - Bull Cancer. 2016 May 25. pii: S0007-4551(16)30041-8. doi:
+      10.1016/j.bulcan.2016.04.003.
+
+PMID- 27236844
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1878-5905 (Electronic)
+IS  - 0142-9612 (Linking)
+VI  - 100
+DP  - 2016 May 18
+TI  - Dual targeting luminescent gold nanoclusters for tumor imaging and deep tissue
+      therapy.
+PG  - 1-16
+LID - S0142-9612(16)30190-9 [pii]
+LID - 10.1016/j.biomaterials.2016.05.017 [doi]
+AB  - Dual targeting towards both extracellular and intracellular receptors specific to
+      tumor is a significant approach for cancer diagnosis and therapy. In the present 
+      study, a novel nano-platform (AuNC-cRGD-Apt) with dual targeting function was
+      initially established by conjugating gold nanocluster (AuNC) with cyclic RGD
+      (cRGD) that is specific to alphavbeta3integrins over-expressed on the surface of 
+      tumor tissues and aptamer AS1411 (Apt) that is of high affinity to nucleolin
+      over-expressed in the cytoplasm and nucleus of tumor cells. Then, AuNC-cRGD-Apt
+      was further functionalized with near infrared (NIR) fluorescence dye (MPA),
+      giving a NIR fluorescent dual-targeting probe AuNC-MPA-cRGD-Apt.
+      AuNC-MPA-cRGD-Apt displays low cytotoxicity and favorable tumor-targeting
+      capability at both in vitro and in vivo level, suggesting its clinical potential 
+      for tumor imaging. Additionally, Doxorubicin (DOX), a widely used clinical
+      chemotherapeutic drug that kill cancer cells by intercalating DNA in cellular
+      nucleus, was immobilized onto AuNC-cRGD-Apt forming a pro-drug,
+      AuNC-DOX-cRGD-Apt. The enhanced tumor affinity, deep tumor penetration and
+      improved anti-tumor activity of this pro-drug were demonstrated in different
+      tumor cell lines, tumor spheroid and tumor-bearing mouse models. Results in this 
+      study suggest not only the prospect of non-toxic AuNC modified with two targeting
+      ligands for tumor targeted imaging, but also confirm the promising future of dual
+      targeting AuNC as a core for the design of prodrug in the field of cancer
+      therapy.
+CI  - Copyright (c) 2016 Elsevier Ltd. All rights reserved.
+FAU - Chen, Dan
+AU  - Chen D
+AD  - Department of Biomedical Engineering, School of Engineering, State Key Laboratory
+      of Natural Medicines, China Pharmaceutical University, 24 Tongjia Lane, Gulou
+      District, Nanjing 210009, China.
+FAU - Li, Bowen
+AU  - Li B
+AD  - Department of Bioengineering, University of Washington, Seattle, USA.
+FAU - Cai, Songhua
+AU  - Cai S
+AD  - Nanjing University Sub-Atomic Resolution Electron Microscopy Laboratory, College 
+      of Engineering and Applied Sciences, Nanjing University, China.
+FAU - Wang, Peng
+AU  - Wang P
+AD  - Nanjing University Sub-Atomic Resolution Electron Microscopy Laboratory, College 
+      of Engineering and Applied Sciences, Nanjing University, China.
+FAU - Peng, Shuwen
+AU  - Peng S
+AD  - Department of Biomedical Engineering, School of Engineering, State Key Laboratory
+      of Natural Medicines, China Pharmaceutical University, 24 Tongjia Lane, Gulou
+      District, Nanjing 210009, China.
+FAU - Sheng, Yuanzhi
+AU  - Sheng Y
+AD  - Department of Biomedical Engineering, School of Engineering, State Key Laboratory
+      of Natural Medicines, China Pharmaceutical University, 24 Tongjia Lane, Gulou
+      District, Nanjing 210009, China.
+FAU - He, Yuanyuan
+AU  - He Y
+AD  - Department of Biomedical Engineering, School of Engineering, State Key Laboratory
+      of Natural Medicines, China Pharmaceutical University, 24 Tongjia Lane, Gulou
+      District, Nanjing 210009, China.
+FAU - Gu, Yueqing
+AU  - Gu Y
+AD  - Department of Biomedical Engineering, School of Engineering, State Key Laboratory
+      of Natural Medicines, China Pharmaceutical University, 24 Tongjia Lane, Gulou
+      District, Nanjing 210009, China. Electronic address:
+      guyueqingsubmission@hotmail.com.
+FAU - Chen, Haiyan
+AU  - Chen H
+AD  - Department of Biomedical Engineering, School of Engineering, State Key Laboratory
+      of Natural Medicines, China Pharmaceutical University, 24 Tongjia Lane, Gulou
+      District, Nanjing 210009, China. Electronic address: chenhaiyan@cpu.edu.cn.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160518
+TA  - Biomaterials
+JT  - Biomaterials
+JID - 8100316
+OTO - NOTNLM
+OT  - Aptamer
+OT  - Gold nanoclusters
+OT  - Tumor diagnosis
+OT  - Tumor spheroid
+OT  - Tumor-targeting
+OT  - Tumor-targeting therapy
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/02/27 [received]
+PHST- 2016/05/12 [revised]
+PHST- 2016/05/14 [accepted]
+AID - S0142-9612(16)30190-9 [pii]
+AID - 10.1016/j.biomaterials.2016.05.017 [doi]
+PST - aheadofprint
+SO  - Biomaterials. 2016 May 18;100:1-16. doi: 10.1016/j.biomaterials.2016.05.017.
+
+PMID- 27236820
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1573-4919 (Electronic)
+IS  - 0300-8177 (Linking)
+DP  - 2016 May 28
+TI  - Inhibition of p90 ribosomal S6 kinase attenuates cell migration and proliferation
+      of the human lung adenocarcinoma through phospho-GSK-3beta and osteopontin.
+AB  - p90 ribosomal S6 kinase (p90RSK) constitutes a family of serine/threonine kinases
+      that have been shown to be involved in cell proliferation of various malignancies
+      via direct or indirect effects on the cell-cycle machinery. We investigated the
+      role of p90RSK in lung adenocarcinomas and whether the inhibition of p90RSK
+      diminishes cancer progression. Moreover, we investigated the involvement of
+      glycogen synthase kinase-3beta (GSK-3beta) and osteopontin (OPN) in the
+      p90RSK-induced lung adenocarcinoma progression. p90RSK, OPN, and GSK-3beta
+      protein expressions were examined in the A549 human lung adenocarcinoma cell line
+      in the presence and absence of BI-D1870 (BID), a p90RSK inhibitor. Gene
+      expression of anti-apoptotic and pro-apoptotic markers namely Bcl2 and Bax,
+      respectively, were studied by reverse transcription polymerase chain reaction. In
+      addition, the A549 lung adenocarcinoma cell line was characterized for cell
+      proliferation using the MTT assay and cell migration using the scratch migration 
+      assay. Our study revealed that total RSK1 protein expression is over expressed in
+      the A549 human lung adenocarcinoma cell line, an effect which is significantly
+      reduced upon pretreatment with BID (69.32 +/- 12.41 % of control; P < 0.05). The 
+      inhibition of p90RSK also showed a significant suppression of cell proliferation 
+      (54.3 +/- 6.73 % of control; P < 0.01) and cell migration (187.90 +/- 16.10 % of 
+      control; P < 0.01). Treatment of the A549 cells with BID regressed the expression
+      of Bcl2 mRNA (56.92 +/- 6.07 % of control; P < 0.01). BID also regressed protein 
+      expression of OPN (79.57 +/- 5.32 % of control; P < 0.05) and phospho-GSK-3beta
+      (73.04 +/- 8.95 % of control; P < 0.05). The p90RSK has an essential role in
+      promoting tumor growth and proliferation in non-small cell lung cancer (NSCLC).
+      BID may serve as an alternative cancer treatment in NSCLC.
+FAU - Abdulrahman, Nabeel
+AU  - Abdulrahman N
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+FAU - Jaballah, Maiy
+AU  - Jaballah M
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+FAU - Poomakkoth, Noufira
+AU  - Poomakkoth N
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+FAU - Riaz, Sadaf
+AU  - Riaz S
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+FAU - Abdelaziz, Somaia
+AU  - Abdelaziz S
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+FAU - Issa, Aya
+AU  - Issa A
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+FAU - Mraiche, Fatima
+AU  - Mraiche F
+AD  - College of Pharmacy, Qatar University, P.O. Box 2713, Doha, Qatar.
+      fatima.mraiche@qu.edu.qa.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160528
+TA  - Mol Cell Biochem
+JT  - Molecular and cellular biochemistry
+JID - 0364456
+OTO - NOTNLM
+OT  - Anti-apoptosis
+OT  - Cell migration
+OT  - Cell proliferation
+OT  - Glycogen synthase kinase-3beta
+OT  - Lung adenocarcinoma
+OT  - Osteopontin
+OT  - p90 Ribosomal S6 kinase
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/03/07 [received]
+PHST- 2016/05/20 [accepted]
+PHST- 2016/05/28 [aheadofprint]
+AID - 10.1007/s11010-016-2727-9 [doi]
+AID - 10.1007/s11010-016-2727-9 [pii]
+PST - aheadofprint
+SO  - Mol Cell Biochem. 2016 May 28.
+
+PMID- 27236819
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1573-2649 (Electronic)
+IS  - 0962-9343 (Linking)
+DP  - 2016 May 28
+TI  - Factors associated with quality of life of caregivers of Mexican cancer patients.
+AB  - PURPOSE: To evaluate factors associated with a poor quality of life (QoL) of
+      caregivers of Mexican cancer patients. METHODS: This is a secondary analysis of a
+      cross-sectional survey of 826 primary caregivers of adult cancer patients at the 
+      Oncology Hospital of the Mexican Institute of Social Security. Dependent
+      variables were physical composite score (PCS) and mental composite score (MCS) of
+      QoL of caregivers measured by the Short Form (SF-12) of Medical Outcomes Survey
+      questionnaire. Independent variables included general characteristics of the
+      caregivers, their unmet needs, caregiving and characteristics of cancer patients.
+      Multiple linear regression analysis for each QoL composite score was carried out.
+      RESULTS: The average PCS was 48.7 and MCS was 47.1. Lower PCS was associated with
+      older age, symptoms of chronic illness, depression and unmet personal needs,
+      while concerns about the future were associated with higher physical QoL. Lower
+      MCS was associated with anxiety, depression, unmet personal and emotional needs, 
+      and surgery in the last month. Caring for patients with a high global health
+      status was associated with a higher MCS. CONCLUSION: Information about
+      caregivers' QoL and its associated factors is important in order to identify and 
+      address modifiable factors. Also, studies from different cultures like Mexico are
+      essential in order to identify possible generalities and particularities in QoL
+      and its associated factors. Given the limitations of the cross-sectional design
+      of our study, future longitudinal studies on the changes of Mexican caregivers'
+      quality of life and their determinants will be an important step to further
+      understanding these phenomena.
+FAU - Doubova, Svetlana V
+AU  - Doubova SV
+AD  - Epidemiology and Health Services Research Unit, CMN Siglo XXI, Mexican Institute 
+      of Social Security, Av. Cuauhtemoc 330, Col. Doctores, Del. Cuauhtemoc, Mexico
+      City, CP 06720, Mexico. svetlana.doubova@gmail.com.
+FAU - Infante-Castaneda, Claudia
+AU  - Infante-Castaneda C
+AD  - Instituto de Investigaciones Sociales, Universidad Nacional Autonoma de Mexico,
+      Mexico City, Mexico.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160528
+TA  - Qual Life Res
+JT  - Quality of life research : an international journal of quality of life aspects of
+      treatment, care and rehabilitation
+JID - 9210257
+OTO - NOTNLM
+OT  - Cancer
+OT  - Caregiver
+OT  - Mexico
+OT  - Quality of life
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/05/18 [accepted]
+PHST- 2016/05/28 [aheadofprint]
+AID - 10.1007/s11136-016-1322-6 [doi]
+AID - 10.1007/s11136-016-1322-6 [pii]
+PST - aheadofprint
+SO  - Qual Life Res. 2016 May 28.
+
+PMID- 27236817
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1432-1084 (Electronic)
+IS  - 0938-7994 (Linking)
+DP  - 2016 May 28
+TI  - Comparison of visibility of circumscribed masses on Digital Breast Tomosynthesis 
+      (DBT) and 2D mammography: are circumscribed masses better visualized and assured 
+      of being benign on DBT?
+AB  - OBJECTIVE: To compare the visibility of circumscribed masses on digital breast
+      tomosynthesis (DBT) images and 2D mammograms and determine the usefulness of DBT 
+      for differentiation between benign and malignant circumscribed masses. METHODS:
+      Seventy-one (19 malignant and 52 benign) mammographic well-circumscribed masses
+      were included. Visibility of the masses and halo signs on DBT images were
+      retrospectively compared with 2D mammograms. The effects of mammographic breast
+      density on mass visibility were also evaluated. RESULTS: For DBT, 83% were
+      superior and 17% were equivalent in visibility of the masses to that of 2D, and
+      superiority of DBT was significantly enhanced in the high breast density group
+      compared with the low breast density group (91% vs 68%, respectively, p = 0.016).
+      Three lesions were only detected on DBT. There was no significant difference in
+      the superiority of DBT for lesion visibility between malignant and benign masses.
+      The halo sign was detected in 58% lesions on DBT and in 4% on 2D (p < 0.001).
+      CONCLUSION: Circumscribed masses were better visualized on DBT than on 2D
+      mammograms, particularly in high-density breasts. The halo sign often appeared on
+      DBT and gave a clearer mass margin. However, circumscribed masses on DBT are not 
+      assured of being benign. KEY POINTS: * Circumscribed masses were better
+      visualized on breast tomosynthesis than on 2D mammography. * Tomosynthesis
+      visualized circumscribed masses better than 2D for all breast density categories.
+      * Halo signs often appeared on tomosynthesis and contributed to detect
+      circumscribed margins. * Circumscribed masses on tomosynthesis images are not
+      assured of being benign lesions.
+FAU - Nakashima, Kazuaki
+AU  - Nakashima K
+AD  - Breast Imaging and Breast Intervention Section, Shizuoka Cancer Center Hospital, 
+      Nagaizumi, Shizuoka, 411-8777, Japan. kaz.nakashima@scchr.jp.
+FAU - Uematsu, Takayoshi
+AU  - Uematsu T
+AD  - Breast Imaging and Breast Intervention Section, Shizuoka Cancer Center Hospital, 
+      Nagaizumi, Shizuoka, 411-8777, Japan.
+FAU - Itoh, Takahiro
+AU  - Itoh T
+AD  - Department of Diagnostic Radiology, Shizuoka Cancer Center Hospital, Nagaizumi,
+      Shizuoka, 411-8777, Japan.
+FAU - Takahashi, Kaoru
+AU  - Takahashi K
+AD  - Department of Breast Surgery, Shizuoka Cancer Center Hospital, Nagaizumi,
+      Shizuoka, 411-8777, Japan.
+FAU - Nishimura, Seiichirou
+AU  - Nishimura S
+AD  - Department of Breast Surgery, Shizuoka Cancer Center Hospital, Nagaizumi,
+      Shizuoka, 411-8777, Japan.
+FAU - Hayashi, Tomomi
+AU  - Hayashi T
+AD  - Department of Breast Surgery, Shizuoka Cancer Center Hospital, Nagaizumi,
+      Shizuoka, 411-8777, Japan.
+FAU - Sugino, Takashi
+AU  - Sugino T
+AD  - Department of Pathology, Shizuoka Cancer Center Hospital, Nagaizumi, Shizuoka,
+      411-8777, Japan.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160528
+TA  - Eur Radiol
+JT  - European radiology
+JID - 9114774
+OTO - NOTNLM
+OT  - Breast tomosynthesis
+OT  - Circumscribed
+OT  - Dense breast
+OT  - Halo
+OT  - Mammography
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/03/17 [received]
+PHST- 2016/05/13 [accepted]
+PHST- 2016/04/30 [revised]
+PHST- 2016/05/28 [aheadofprint]
+AID - 10.1007/s00330-016-4420-5 [doi]
+AID - 10.1007/s00330-016-4420-5 [pii]
+PST - aheadofprint
+SO  - Eur Radiol. 2016 May 28.
+
+PMID- 27236807
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Redirecting T Cell Specificity Using T Cell Receptor Messenger RNA
+      Electroporation.
+PG  - 285-96
+LID - 10.1007/978-1-4939-3625-0_19 [doi]
+AB  - Autologous T lymphocytes genetically modified to express T cell receptors or
+      chimeric antigen receptors have shown great promise in the treatment of several
+      cancers, including melanoma and leukemia. In addition to tumor-associated
+      antigens and tumor-specific neoantigens, tumors expressing viral peptides can
+      also be recognized by specific T cells and are attractive targets for cell
+      therapy. Hepatocellular carcinoma cells often have hepatitis B virus DNA
+      integration and can be targeted by hepatitis B virus-specific T cells. Here, we
+      describe a method to engineer hepatitis B virus-specific T cell receptors in
+      primary human T lymphocytes based on electroporation of hepatitis B virus T cell 
+      receptor messenger RNA. This method can be extended to a large scale therapeutic 
+      T cell production following current good manufacturing practice compliance and is
+      applicable to the redirection of T lymphocytes with T cell receptors of other
+      virus specificities such as Epstein-Barr virus, cytomegalovirus, and chimeric
+      receptors specific for other antigens expressed on cancer cells.
+FAU - Koh, Sarene
+AU  - Koh S
+AD  - Singapore Institute for Clinical Sciences, Brenner Center for Molecular Medicine,
+      Agency for Science, Technology and Research, (A*STAR), 30 Medical Drive,
+      Singapore, Singapore. sarene_koh@sics.a-star.edu.sg.
+FAU - Shimasaki, Noriko
+AU  - Shimasaki N
+AD  - Department of Pediatrics, Yong Loo Lin School of Medicine, National University of
+      Singapore, Singapore, Singapore.
+FAU - Bertoletti, Antonio
+AU  - Bertoletti A
+AD  - Emerging Infectious Diseases Program, Duke-NUS Graduate Medical School,
+      Singapore, Singapore.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cell therapy
+OT  - Electroporation
+OT  - Hepatitis B virus
+OT  - Hepatocellular carcinoma
+OT  - Messenger RNA
+OT  - T cell receptor
+OT  - T cells
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_19 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:285-96. doi: 10.1007/978-1-4939-3625-0_19.
+
+PMID- 27236806
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - mRNA Electroporation of Dendritic Cells with WT1, Survivin, and TriMix (a Mixture
+      of caTLR4, CD40L, and CD70).
+PG  - 277-83
+LID - 10.1007/978-1-4939-3625-0_18 [doi]
+AB  - The immune system is a crucial player in the development of cancer. Once it is in
+      imbalance and immunosuppressive mechanisms supporting tumor growth take over
+      control, dendritic cell immunotherapy might offer a solution to restore the
+      balance. There are several methods to manufacture dendritic cells but none of
+      them has yet proven to be superior to others. In this chapter, we discuss the
+      methodology using electroporation of mRNA encoding Wilms' tumor gene 1, survivin,
+      and TriMix (mixture of caTLR4, CD40L, and CD70) to simultaneously load and mature
+      dendritic cells.
+FAU - Coosemans, An
+AU  - Coosemans A
+AD  - Laboratory of Gynecologic Oncology, Department of Oncology, KU Leuven, Leuven
+      Cancer Institute, Leuven, Belgium. an.coosemans@gmail.com.
+AD  - Department of Gynecology and Obstetrics, UZ Leuven, Herestraat 49, 3000, Leuven, 
+      Belgium. an.coosemans@gmail.com.
+FAU - Tuyaerts, Sandra
+AU  - Tuyaerts S
+AD  - Laboratory of Gynecologic Oncology, Department of Oncology, KU Leuven, Leuven
+      Cancer Institute, Leuven, Belgium.
+FAU - Morias, Kim
+AU  - Morias K
+AD  - Department of Human Genetics, KU Leuven, Leuven, Belgium.
+FAU - Corthals, Jurgen
+AU  - Corthals J
+AD  - Laboratory of Molecular and Cellular Therapy (LMCT), Vrije Universiteit Brussel, 
+      Brussels, Belgium.
+FAU - Heirman, Carlo
+AU  - Heirman C
+AD  - Laboratory of Molecular and Cellular Therapy (LMCT), Vrije Universiteit Brussel, 
+      Brussels, Belgium.
+FAU - Thielemans, Kris
+AU  - Thielemans K
+AD  - Laboratory of Molecular and Cellular Therapy (LMCT), Vrije Universiteit Brussel, 
+      Brussels, Belgium.
+FAU - Van Gool, Stefaan W
+AU  - Van Gool SW
+AD  - Laboratory of Pediatric Immunology, Department of Microbiology and Immunology, KU
+      Leuven, Leuven, Belgium.
+FAU - Vergote, Ignace
+AU  - Vergote I
+AD  - Laboratory of Gynecologic Oncology, Department of Oncology, KU Leuven, Leuven
+      Cancer Institute, Leuven, Belgium.
+AD  - Department of Gynecology and Obstetrics, UZ Leuven, Herestraat 49, 3000, Leuven, 
+      Belgium.
+FAU - Amant, Frederic
+AU  - Amant F
+AD  - Laboratory of Gynecologic Oncology, Department of Oncology, KU Leuven, Leuven
+      Cancer Institute, Leuven, Belgium.
+AD  - Department of Gynecology and Obstetrics, UZ Leuven, Herestraat 49, 3000, Leuven, 
+      Belgium.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Dendritic cell
+OT  - Electroporation
+OT  - Survivin
+OT  - TriMix
+OT  - WT1
+OT  - mRNA
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_18 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:277-83. doi: 10.1007/978-1-4939-3625-0_18.
+
+PMID- 27236805
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Transfection of Tumor-Infiltrating T Cells with mRNA Encoding CXCR2.
+PG  - 261-76
+LID - 10.1007/978-1-4939-3625-0_17 [doi]
+AB  - Adoptive T-cell therapy based on the infusion of patient's own immune cells after
+      ex vivo culturing is among the most potent forms of personalized treatment among 
+      recent clinical developments for the treatment of cancer. However, despite high
+      rates of successful initial clinical responses, only about 20 % of patients with 
+      metastatic melanoma treated with tumor-infiltrating lymphocytes (TILs) enter
+      complete and long-term regression, with the majority either relapsing after
+      initial partial regression or not benefiting at all. Previous studies have shown 
+      a positive correlation between the number infused T cells migrating to the tumor 
+      and the clinical response, but also that only a small fraction of adoptively
+      transferred T cells reach the tumor site. In this chapter, we describe a protocol
+      for transfection of TILs with mRNA encoding the chemokine receptor CXCR2
+      transiently redirecting and improving TILs migration toward tumor-secreted
+      chemokines in vitro.
+FAU - Idorn, Manja
+AU  - Idorn M
+AD  - Center for Cancer Immune Therapy (CCIT), Department of Hematology, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+      manja.idorn@regionh.dk.
+FAU - Thor Straten, Per
+AU  - Thor Straten P
+AD  - Center for Cancer Immune Therapy (CCIT), Department of Hematology, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+FAU - Svane, Inge Marie
+AU  - Svane IM
+AD  - Center for Cancer Immune Therapy (CCIT), Department of Hematology, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+AD  - Department of Oncology, Copenhagen University Hospital Herlev, Herlev Ringvej 75,
+      2730, Herlev, Denmark.
+FAU - Met, Ozcan
+AU  - Met O
+AD  - Center for Cancer Immune Therapy (CCIT), Department of Hematology, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+AD  - Department of Oncology, Copenhagen University Hospital Herlev, Herlev Ringvej 75,
+      2730, Herlev, Denmark.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cancer immunotherapy
+OT  - Chemokine receptor
+OT  - Tumor homing
+OT  - Tumor-infiltrating lymphocytes (TILs)
+OT  - mRNA transfection
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_17 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:261-76. doi: 10.1007/978-1-4939-3625-0_17.
+
+PMID- 27236804
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Immune Monitoring Using mRNA-Transfected Dendritic Cells.
+PG  - 245-59
+LID - 10.1007/978-1-4939-3625-0_16 [doi]
+AB  - Dendritic cells are known to be the most potent antigen presenting cell in the
+      immune system and are used as cellular adjuvants in therapeutic anticancer
+      vaccines using various tumor-associated antigens or their derivatives. One way of
+      loading antigen into the dendritic cells is by mRNA electroporation, ensuring
+      presentation of antigen through major histocompatibility complex I and
+      potentially activating T cells, enabling them to kill the tumor cells. Despite
+      extensive research in the field, only one dendritic cell-based vaccine has been
+      approved. There is therefore a great need to elucidate and understand the
+      immunological impact of dendritic cell vaccination in order to improve clinical
+      benefit. In this chapter, we describe a method for performing immune monitoring
+      using peripheral blood mononuclear cells and autologous dendritic cells
+      transfected with tumor-associated antigen-encoding mRNA.
+FAU - Borch, Troels Holz
+AU  - Borch TH
+AD  - Department of Haematology, Center for Cancer Immune Therapy, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+      troels.holz.borch@regionh.dk.
+AD  - Department of Oncology, Copenhagen University Hospital Herlev, Herlev, Denmark.
+      troels.holz.borch@regionh.dk.
+FAU - Svane, Inge Marie
+AU  - Svane IM
+AD  - Department of Haematology, Center for Cancer Immune Therapy, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+AD  - Department of Oncology, Copenhagen University Hospital Herlev, Herlev, Denmark.
+FAU - Met, Ozcan
+AU  - Met O
+AD  - Department of Haematology, Center for Cancer Immune Therapy, Copenhagen
+      University Hospital Herlev, Herlev Ringvej 75, 2730, Herlev, Denmark.
+AD  - Department of Oncology, Copenhagen University Hospital Herlev, Herlev, Denmark.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cancer immunotherapy
+OT  - Dendritic cell
+OT  - Electroporation
+OT  - Immune monitoring
+OT  - Vaccination
+OT  - mRNA transfection
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_16 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:245-59. doi: 10.1007/978-1-4939-3625-0_16.
+
+PMID- 27236803
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Delivery of Synthetic mRNA Encoding FOXP3 Antigen into Dendritic Cells for
+      Inflammatory Breast Cancer Immunotherapy.
+PG  - 231-43
+LID - 10.1007/978-1-4939-3625-0_15 [doi]
+AB  - Dendritic cell (DC)-based vaccines are commonly used for cancer immunotherapy. To
+      prepare vaccines, DCs are pulsed or transfected with either: (a) defined peptides
+      of tumor-associated antigens, (b) total protein isolated from the tumor cell, (c)
+      autologous total RNA isolated from the tumor cell, (d) synthetic
+      tumor-antigen-encoding mRNA, or (e) genes that encode for specific
+      tumor-associated antigens. Introduction of tumor-associated antigen(s) and
+      subsequent generation of mature DCs that can stimulate tumor-antigen-specific
+      cytotoxic T lymphocytes comprise the critical steps of cancer vaccine
+      preparation. Here, we described a method of: (a) preparing and delivering
+      synthetic FOXP3 mRNA into human DCs, (b) generating mature DCs,
+CI  - (c) generating FOXP3-specific cytotoxic T lymphocytes, and (d) evaluating
+      cytotoxicity of FOXP3-specific cytotoxic T lymphocytes against inflammatory
+      breast cancer cells.
+FAU - Devi, Gayathri R
+AU  - Devi GR
+AD  - Division of Surgical Sciences, Department of Surgery, Women's Cancer Program,
+      Duke Cancer Institute, Duke University School of Medicine, Durham, NC, 27710,
+      USA. gayathri.devi@duke.edu.
+FAU - Nath, Sritama
+AU  - Nath S
+AD  - Division of Surgical Sciences, Department of Surgery, Women's Cancer Program,
+      Duke Cancer Institute, Duke University School of Medicine, Durham, NC, 27710,
+      USA.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cancer vaccines
+OT  - Cytotoxic T lymphocyte (CTL) assay
+OT  - Dendritic cell
+OT  - Electroporation
+OT  - Lipofection
+OT  - Synthetic mRNA
+OT  - Tumor-associated antigens
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_15 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:231-43. doi: 10.1007/978-1-4939-3625-0_15.
+
+PMID- 27236799
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - FLT3 Ligand as a Molecular Adjuvant for Naked RNA Vaccines.
+PG  - 163-75
+LID - 10.1007/978-1-4939-3625-0_11 [doi]
+AB  - Intranodal immunization with antigen-encoding naked mRNA has proven to be an
+      efficacious and safe approach to induce antitumor immunity. Thanks to its unique 
+      characteristics, mRNA can act not only as a source for antigen but also as an
+      adjuvant for activation of the immune system. The search for additional adjuvants
+      that can be combined with mRNA to further improve the potency of the immunization
+      revealed Fms-like tyrosine kinase 3 (FLT3) ligand as a potent candidate. Systemic
+      administration of the dendritic cell-activating FLT3 ligand prior to or along
+      with mRNA immunization-enhanced priming and expansion of antigen-specific CD8(+) 
+      T cells in lymphoid organs, T-cell homing into melanoma tumors, and therapeutic
+      activity of the intranodally administered mRNA. Both compounds demonstrate a
+      successful combination in terms of boosting the immune response. This chapter
+      describes methods for intranodal immunization with naked mRNA by
+      co-administration of FLT3 ligand, which leads to strong synergistic effects.
+FAU - Kreiter, Sebastian
+AU  - Kreiter S
+AD  - TRON-Translational Oncology at the University Medical Center of Johannes
+      Gutenberg University, TRON gGmbH, Freiligrathstrasse 12, 55131, Mainz, Germany.
+FAU - Diken, Mustafa
+AU  - Diken M
+AD  - TRON-Translational Oncology at the University Medical Center of Johannes
+      Gutenberg University, TRON gGmbH, Freiligrathstrasse 12, 55131, Mainz, Germany.
+FAU - Selmi, Abderraouf
+AU  - Selmi A
+AD  - TRON-Translational Oncology at the University Medical Center of Johannes
+      Gutenberg University, TRON gGmbH, Freiligrathstrasse 12, 55131, Mainz, Germany.
+FAU - Petschenka, Jutta
+AU  - Petschenka J
+AD  - TRON-Translational Oncology at the University Medical Center of Johannes
+      Gutenberg University, TRON gGmbH, Freiligrathstrasse 12, 55131, Mainz, Germany.
+FAU - Tureci, Ozlem
+AU  - Tureci O
+AD  - TRON-Translational Oncology at the University Medical Center of Johannes
+      Gutenberg University, TRON gGmbH, Freiligrathstrasse 12, 55131, Mainz, Germany.
+FAU - Sahin, Ugur
+AU  - Sahin U
+AD  - TRON-Translational Oncology at the University Medical Center of Johannes
+      Gutenberg University, TRON gGmbH, Freiligrathstrasse 12, 55131, Mainz, Germany.
+      ugur.sahin@tron-mainz.de.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cancer vaccination
+OT  - Dendritic cell
+OT  - FLT3 ligand
+OT  - IVT-RNA
+OT  - Immunotherapy
+OT  - Intranodal injection
+OT  - RNA vaccine
+OT  - Vaccine adjuvants
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_11 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:163-75. doi: 10.1007/978-1-4939-3625-0_11.
+
+PMID- 27236798
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Large-Scale mRNA Transfection of Dendritic Cells by Electroporation in Continuous
+      Flow Systems.
+PG  - 151-61
+LID - 10.1007/978-1-4939-3625-0_10 [doi]
+AB  - Electroporation is well established for transient mRNA transfection of many
+      mammalian cells, including immune cells such as dendritic cells used in cancer
+      immunotherapy. Therapeutic application requires methods to efficiently
+      electroporate and transfect millions of immune cells in a fast process with high 
+      cell survival. Continuous flow of suspended dendritic cells through a channel
+      incorporating spatially separated microporous meshes with a synchronized
+      electrical pulsing sequence can yield dendritic cell transfection rates of >75 % 
+      with survival rates of >90 %. This chapter describes the instrumentation and
+      methods needed for the efficient transfection by electroporation of millions of
+      dendritic cells in one continuous flow process.
+FAU - Selmeczi, David
+AU  - Selmeczi D
+AD  - Department of Micro- and Nanotechnology, DTU Nanotech, Technical University of
+      Denmark, Orsteds Plads 345B, 2800, Kgs. Lyngby, Denmark.
+FAU - Hansen, Thomas Steen
+AU  - Hansen TS
+AD  - Department of Micro- and Nanotechnology, DTU Nanotech, Technical University of
+      Denmark, Orsteds Plads 345B, 2800, Kgs. Lyngby, Denmark.
+FAU - Met, Ozcan
+AU  - Met O
+AD  - Center for Cancer Immune Therapy, Department of Hematology, Herlev Hospital,
+      Copenhagen University, Copenhagen, Denmark.
+AD  - Department of Oncology, Herlev Hospital, Copenhagen University, Copenhagen,
+      Denmark.
+FAU - Svane, Inge Marie
+AU  - Svane IM
+AD  - Center for Cancer Immune Therapy, Department of Hematology, Herlev Hospital,
+      Copenhagen University, Copenhagen, Denmark.
+AD  - Department of Oncology, Herlev Hospital, Copenhagen University, Copenhagen,
+      Denmark.
+FAU - Larsen, Niels B
+AU  - Larsen NB
+AD  - Department of Micro- and Nanotechnology, DTU Nanotech, Technical University of
+      Denmark, Orsteds Plads 345B, 2800, Kgs. Lyngby, Denmark.
+      niels.b.larsen@nanotech.dtu.dk.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Dendritic cells
+OT  - Electroporation
+OT  - Laminar flow
+OT  - Microfluidics
+OT  - Transfection
+OT  - mRNA
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_10 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:151-61. doi: 10.1007/978-1-4939-3625-0_10.
+
+PMID- 27236797
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - GMP-Grade mRNA Electroporation of Dendritic Cells for Clinical Use.
+PG  - 139-50
+LID - 10.1007/978-1-4939-3625-0_9 [doi]
+AB  - mRNA-electroporated dendritic cells (DC) are demonstrating clinical benefit in
+      patients in many therapeutic areas, including cancer and infectious diseases.
+      According to current good manufacturing guidelines, cell-based medicinal products
+      have to be defined for identity, purity, potency, stability, and viability. In
+      order to comply with the directives and guidelines defined by the regulatory
+      authorities, we report here a standardized and reproducible method for the
+      manufacturing of clinical-grade mRNA-transfected DC.
+FAU - Derdelinckx, Judith
+AU  - Derdelinckx J
+AD  - Laboratory of Experimental Hematology, Vaccine & Infectious Disease Institute
+      (VAXINFECTIO), Faculty of Medicine and Health Sciences, University of Antwerp,
+      Antwerp University Hospital (UZA), Wilrijkstraat 10, B-2650, Edegem, Belgium.
+FAU - Berneman, Zwi N
+AU  - Berneman ZN
+AD  - Laboratory of Experimental Hematology, Vaccine & Infectious Disease Institute
+      (VAXINFECTIO), Faculty of Medicine and Health Sciences, University of Antwerp,
+      Antwerp University Hospital (UZA), Wilrijkstraat 10, B-2650, Edegem, Belgium.
+FAU - Cools, Nathalie
+AU  - Cools N
+AD  - Laboratory of Experimental Hematology, Vaccine & Infectious Disease Institute
+      (VAXINFECTIO), Faculty of Medicine and Health Sciences, University of Antwerp,
+      Antwerp University Hospital (UZA), Wilrijkstraat 10, B-2650, Edegem, Belgium.
+      nathalie.cools@uza.be.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cell therapy
+OT  - Dendritic cells
+OT  - Electroporation
+OT  - Good manufacturing practices (GMP)
+OT  - mRNA
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_9 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:139-50. doi: 10.1007/978-1-4939-3625-0_9.
+
+PMID- 27236795
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Engineering WT1-Encoding mRNA to Increase Translational Efficiency in Dendritic
+      Cells.
+PG  - 115-23
+LID - 10.1007/978-1-4939-3625-0_7 [doi]
+AB  - Dendritic cells (DCs) are the orchestrators of the immune system and are
+      frequently used in clinical trials in order to boost the immune system in cancer 
+      patients. Among several available techniques for DC modification, mRNA
+      electroporation is an interesting technique due to the favorable characteristics 
+      of mRNA. Antigen expression level and duration can be increased by multiple
+      optimizations of an antigen-encoding mRNA template. Here, we describe different
+      molecular modifications to a WT1-encoding mRNA construct in order to increase
+      antigen expression and the subsequent introduction of mRNA into DCs.
+FAU - Benteyn, Daphne
+AU  - Benteyn D
+AD  - Laboratory of Molecular and Cellular Therapy, Department of Immunology-Physiology
+      and the Dendritic Cell Bank, Vrije Universiteit Brussel, Laarbeeklaan 103/E235,
+      1090, Brussels, Belgium. Daphne.benteyn@vub.ac.be.
+FAU - Heirman, Carlo
+AU  - Heirman C
+AD  - Laboratory of Molecular and Cellular Therapy, Department of Immunology-Physiology
+      and the Dendritic Cell Bank, Vrije Universiteit Brussel, Laarbeeklaan 103/E235,
+      1090, Brussels, Belgium.
+FAU - Thielemans, Kris
+AU  - Thielemans K
+AD  - Laboratory of Molecular and Cellular Therapy, Department of Immunology-Physiology
+      and the Dendritic Cell Bank, Vrije Universiteit Brussel, Laarbeeklaan 103/E235,
+      1090, Brussels, Belgium.
+FAU - Bonehill, Aude
+AU  - Bonehill A
+AD  - Laboratory of Molecular and Cellular Therapy, Department of Immunology-Physiology
+      and the Dendritic Cell Bank, Vrije Universiteit Brussel, Laarbeeklaan 103/E235,
+      1090, Brussels, Belgium.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Antigen expression
+OT  - Cancer
+OT  - Dendritic cells
+OT  - Immunotherapy
+OT  - Vaccination
+OT  - Wilms' Tumor 1
+OT  - mRNA
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_7 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:115-23. doi: 10.1007/978-1-4939-3625-0_7.
+
+PMID- 27236789
+OWN - NLM
+STAT- In-Data-Review
+DA  - 20160530
+IS  - 1940-6029 (Electronic)
+IS  - 1064-3745 (Linking)
+VI  - 1428
+DP  - 2016
+TI  - Synthetic mRNA: Production, Introduction into Cells, and Physiological
+      Consequences.
+PG  - 3-27
+LID - 10.1007/978-1-4939-3625-0_1 [doi]
+AB  - Recent advances have made it possible to synthesize mRNA in vitro that is
+      relatively stable when introduced into mammalian cells, has a diminished ability 
+      to activate the innate immune response against exogenous (virus-like) RNA, and
+      can be efficiently translated into protein. Synthetic methods have also been
+      developed to produce mRNA with unique investigational properties such as
+      photo-cross-linking, fluorescence emission, and attachment of ligands through
+      click chemistry. Synthetic mRNA has been proven effective in numerous
+      applications beneficial for human health such as immunizing patients against
+      cancer and infections diseases, alleviating diseases by restoring deficient
+      proteins, converting somatic cells to pluripotent stem cells to use in
+      regenerative medicine therapies, and engineering the genome by making specific
+      alterations in DNA. This introductory chapter provides background information
+      relevant to the following 20 chapters of this volume that present protocols for
+      these applications of synthetic mRNA.
+FAU - Rhoads, Robert E
+AU  - Rhoads RE
+AD  - Department of Biochemistry and Molecular Biology, Louisiana State University
+      Health Sciences Center, Shreveport, LA, 71130-3932, USA. rrhoad@lsuhsc.edu.
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Methods Mol Biol
+JT  - Methods in molecular biology (Clifton, N.J.)
+JID - 9214969
+SB  - IM
+OTO - NOTNLM
+OT  - Cap analogs
+OT  - Cationic lipids
+OT  - Electroporation
+OT  - Immunotherapy
+OT  - Innate immunity
+OT  - Nucleoporation
+OT  - Poly(A)
+OT  - Protein expression
+OT  - Translational efficiency
+OT  - mRNA stability
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+AID - 10.1007/978-1-4939-3625-0_1 [doi]
+PST - ppublish
+SO  - Methods Mol Biol. 2016;1428:3-27. doi: 10.1007/978-1-4939-3625-0_1.
+
+PMID- 27236772
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1938-0682 (Electronic)
+IS  - 1558-7673 (Linking)
+DP  - 2016 Apr 22
+TI  - Overall Survival Analysis From a Randomized Phase II Study of Axitinib With or
+      Without Dose Titration in First-Line Metastatic Renal Cell Carcinoma.
+LID - S1558-7673(16)30095-7 [pii]
+LID - 10.1016/j.clgc.2016.04.005 [doi]
+AB  - BACKGROUND: In a randomized phase II trial in metastatic renal cell carcinoma
+      (mRCC), objective response rate was significantly higher with axitinib versus
+      placebo titration (54% vs. 34%; 1-sided P = .019). PATIENTS AND METHODS:
+      Treatment-naive patients with mRCC (n = 213) received axitinib 5 mg twice per day
+      (b.i.d.) for 4 weeks. Patients meeting dose titration criteria were randomized to
+      receive axitinib 5 mg b.i.d. with axitinib or placebo titration (n = 56 each); 91
+      patients ineligible for randomization continued axitinib 5 mg b.i.d.; 10
+      discontinued before randomization. RESULTS: Median overall survival (95%
+      confidence interval [CI]) was 42.7 months (24.7-not estimable) with axitinib
+      titration versus 30.4 months (23.7-45.0) with placebo titration (stratified
+      hazard ratio, 0.785; 95% CI, 0.485-1.272; 1-sided P = .162), and 41.6 months (95%
+      CI, 33.0-not estimable) in nonrandomized patients. Safety data were consistent
+      with previous reports. CONCLUSION: Median overall survival was numerically longer
+      in patients with first-line mRCC who received axitinib versus placebo titration. 
+      No new safety signal was observed after long-term axitinib treatment in
+      first-line mRCC.
+CI  - Copyright (c) 2016 Elsevier Inc. All rights reserved.
+FAU - Rini, Brian I
+AU  - Rini BI
+AD  - Department of Hematology and Oncology, Cleveland Clinic Taussig Cancer Institute,
+      Cleveland, OH. Electronic address: rinib2@ccf.org.
+FAU - Tomita, Yoshihiko
+AU  - Tomita Y
+AD  - Department of Urology, Department of Molecular Oncology, Niigata University
+      Graduate School of Medical and Dental Sciences, Niigata, Japan.
+FAU - Melichar, Bohuslav
+AU  - Melichar B
+AD  - Palacky University Medical School and Teaching Hospital, Olomouc, Czech Republic.
+FAU - Ueda, Takeshi
+AU  - Ueda T
+AD  - Prostate Center and Division of Urology, Chiba Cancer Center, Chiba, Japan.
+FAU - Grunwald, Viktor
+AU  - Grunwald V
+AD  - Department of Hematology, Hemostasis, Oncology, and Stem Cell Transplantation,
+      Hannover Medical School, Hannover, Germany.
+FAU - Fishman, Mayer N
+AU  - Fishman MN
+AD  - H. Lee Moffitt Cancer Center, Tampa, FL.
+FAU - Uemura, Hirotsugu
+AU  - Uemura H
+AD  - Department of Urology, Kinki University Faculty of Medicine, Osaka, Japan.
+FAU - Oya, Mototsugu
+AU  - Oya M
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan.
+FAU - Bair, Angel H
+AU  - Bair AH
+AD  - Pfizer Oncology, San Diego, CA.
+FAU - Andrews, Glen I
+AU  - Andrews GI
+AD  - Pfizer Oncology, San Diego, CA.
+FAU - Rosbrook, Brad
+AU  - Rosbrook B
+AD  - Pfizer Oncology, San Diego, CA.
+FAU - Jonasch, Eric
+AU  - Jonasch E
+AD  - The University of Texas M.D. Anderson Cancer Center, Houston, TX.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160422
+TA  - Clin Genitourin Cancer
+JT  - Clinical genitourinary cancer
+JID - 101260955
+OTO - NOTNLM
+OT  - First-line treatment
+OT  - Kidney cancer
+OT  - Phase II
+OT  - VEGFR inhibitor
+OT  - mRCC
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/02/17 [received]
+PHST- 2016/04/06 [revised]
+PHST- 2016/04/11 [accepted]
+AID - S1558-7673(16)30095-7 [pii]
+AID - 10.1016/j.clgc.2016.04.005 [doi]
+PST - aheadofprint
+SO  - Clin Genitourin Cancer. 2016 Apr 22. pii: S1558-7673(16)30095-7. doi:
+      10.1016/j.clgc.2016.04.005.
+
+PMID- 27236771
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1938-0682 (Electronic)
+IS  - 1558-7673 (Linking)
+DP  - 2016 May 2
+TI  - Using Interferon Alfa Before Tyrosine Kinase Inhibitors May Increase Survival in 
+      Patients With Metastatic Renal Cell Carcinoma: A Turkish Oncology Group (TOG)
+      Study.
+LID - S1558-7673(16)30111-2 [pii]
+LID - 10.1016/j.clgc.2016.04.021 [doi]
+AB  - BACKGROUND: We aimed to investigate the outcomes of interferon alfa and
+      sequencing tyrosine kinase inhibitors (TKIs) in patients with metastatic renal
+      cell carcinoma. PATIENTS AND METHODS: This multicenter study assessing the
+      efficacy of TKIs after interferon alfa therapy in the first-line setting in
+      patients with metastatic renal cell carcinoma. Patients (n = 104) from 8 centers 
+      in Turkey, who had been treated with interferon alfa in the first-line setting,
+      were included in the study. Prognostic factors were evaluated for
+      progression-free survival (PFS). RESULTS: The median age of the patients was 57
+      years. The median PFS of the patients treated with interferon alfa in the
+      first-line was 3.6 months. A total of 61 patients received TKIs (sunitinib, n =
+      58; sorafenib, n = 3) after progression while on interferon alfa. The median PFS 
+      among the TKI-treated patients was 13.2 months. In the univariate analysis for
+      interferon alfa treatment, neutrophil and hemoglobin level, platelet count, and
+      Karnofsky performance status were the significant factors associated with PFS. In
+      the univariate analysis for TKI treatment, neutrophil and hemoglobin levels were 
+      the significant factors for PFS. The median total PFS of the patients who had
+      been treated with first-line interferon alfa and second-line TKIs was 24.9
+      months. CONCLUSION: This study showed that first-line interferon alfa treatment
+      before TKIs may improve the total PFS in patients with metastatic renal cell
+      carcinoma.
+CI  - Copyright (c) 2016 Elsevier Inc. All rights reserved.
+FAU - Artac, Mehmet
+AU  - Artac M
+AD  - Department of Medical Oncology, Necmettin Erbakan University Meram Medical
+      Faculty, Konya, Turkey. Electronic address: mehmetartac@yahoo.com.
+FAU - Coskun, Hasan Senol
+AU  - Coskun HS
+AD  - Department of Medical Oncology, Akdeniz University Medical Faculty, Antalya,
+      Turkey.
+FAU - Korkmaz, Levent
+AU  - Korkmaz L
+AD  - Department of Medical Oncology, Necmettin Erbakan University Meram Medical
+      Faculty, Konya, Turkey.
+FAU - Kocer, Murat
+AU  - Kocer M
+AD  - Department of Medical Oncology, Suleyman Demirel University Medical Faculty,
+      Isparta, Turkey.
+FAU - Turhal, Nazim Serdar
+AU  - Turhal NS
+AD  - Department of Medical Oncology, Marmara University Medical Faculty, Istanbul,
+      Turkey.
+FAU - Engin, Huseyin
+AU  - Engin H
+AD  - Department of Medical Oncology, Bulent Ecevit University Medical Faculty,
+      Zonguldak, Turkey.
+FAU - Dede, Isa
+AU  - Dede I
+AD  - Department of Medical Oncology, Ankara University Medical Faculty, Ankara,
+      Turkey.
+FAU - Paydas, Semra
+AU  - Paydas S
+AD  - Department of Medical Oncology, Cukurova University Medical Faculty, Adana,
+      Turkey.
+FAU - Oksuzoglu, Berna
+AU  - Oksuzoglu B
+AD  - Department of Medical Oncology, Ankara Oncology Training and Research Hospital,
+      Ankara, Turkey.
+FAU - Bozcuk, Hakan
+AU  - Bozcuk H
+AD  - Department of Medical Oncology, Akdeniz University Faculty of Medicine, Antalya, 
+      Turkey.
+FAU - Demirkazik, Ahmet
+AU  - Demirkazik A
+AD  - Department of Medical Oncology, Ankara University Medical Faculty, Ankara,
+      Turkey.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160502
+TA  - Clin Genitourin Cancer
+JT  - Clinical genitourinary cancer
+JID - 101260955
+OTO - NOTNLM
+OT  - Cytokine therapy
+OT  - Progression free survival
+OT  - Sorafenib
+OT  - Sunitinib
+OT  - VEGF inhibitors
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2015/10/14 [received]
+PHST- 2016/04/20 [revised]
+PHST- 2016/04/25 [accepted]
+AID - S1558-7673(16)30111-2 [pii]
+AID - 10.1016/j.clgc.2016.04.021 [doi]
+PST - aheadofprint
+SO  - Clin Genitourin Cancer. 2016 May 2. pii: S1558-7673(16)30111-2. doi:
+      10.1016/j.clgc.2016.04.021.
+
+PMID- 27236770
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1938-0682 (Electronic)
+IS  - 1558-7673 (Linking)
+DP  - 2016 May 2
+TI  - Are the Formulas Used to Estimate Renal Function Adequate for Patients Treated
+      With Cisplatin-Based Chemotherapy After Nephroureterectomy for Upper Tract
+      Urothelial Carcinoma?
+LID - S1558-7673(16)30108-2 [pii]
+LID - 10.1016/j.clgc.2016.04.018 [doi]
+AB  - OBJECTIVE: The relationship between endogenous creatinine clearance (eCrCl) and
+      renal function values obtained using mathematical formulas has not yet been fully
+      elucidated, especially in patients with upper tract urothelial carcinoma that are
+      treated with radical nephroureterectomy followed by cisplatin-based chemotherapy.
+      METHODS: Sixty patients who received cisplatin-based chemotherapy for locally
+      advanced or metastatic upper tract urothelial carcinoma after radical
+      nephroureterectomy between 2000 and 2012 were retrospectively identified. eCrCl
+      was measured based on 24-hour urine specimens obtained immediately prior to each 
+      cycle of chemotherapy. Renal function was estimated with 4 different formulas:
+      the Cockcroft-Gault, Modification of Diet in Renal Disease, Chronic Kidney
+      Disease Epidemiology Collaboration, and Wright formulas. We evaluated the
+      relationship between eCrCl and the renal function values obtained with each
+      formula using the Pearson correlation coefficient and kappa statistics. RESULTS: 
+      The median eCrCl was 53.9 mL/min. The Pearson correlation coefficients and kappa 
+      statistics for the relationships between eCrCl and the renal function values
+      obtained with each of the mathematical formulas ranged from 0.600 to 0.763 and
+      from 0.29 to 0.67, respectively. Among the patients with eCrCl of >/= 60 mL/min, 
+      70%, 60%, 50%, and 20% were estimated to have the renal function values of < 60
+      mL/min by the Cockcroft-Gault, Modification of Diet in Renal Disease, Chronic
+      Kidney Disease Epidemiology Collaboration, and Wright formulas, respectively.
+      CONCLUSIONS: All 4 of the tested formulas underestimated eCrCl. The values
+      obtained with the Wright formula were most closely associated with eCrCl.
+CI  - Copyright (c) 2016 Elsevier Inc. All rights reserved.
+FAU - Niwa, Naoya
+AU  - Niwa N
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan;
+      Department of Urology, National Hospital Organization Tokyo Medical Center,
+      Tokyo, Japan.
+FAU - Kikuchi, Eiji
+AU  - Kikuchi E
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan.
+      Electronic address: eiji-k@kb3.so-net.ne.jp.
+FAU - Masashi, Matsushima
+AU  - Masashi M
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan.
+FAU - Tanaka, Nobuyuki
+AU  - Tanaka N
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan.
+FAU - Nishiyama, Toru
+AU  - Nishiyama T
+AD  - Department of Urology, National Hospital Organization Tokyo Medical Center,
+      Tokyo, Japan.
+FAU - Miyajima, Akira
+AU  - Miyajima A
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan.
+FAU - Saito, Shiro
+AU  - Saito S
+AD  - Department of Urology, National Hospital Organization Tokyo Medical Center,
+      Tokyo, Japan.
+FAU - Oya, Mototsugu
+AU  - Oya M
+AD  - Department of Urology, Keio University School of Medicine, Tokyo, Japan.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160502
+TA  - Clin Genitourin Cancer
+JT  - Clinical genitourinary cancer
+JID - 101260955
+OTO - NOTNLM
+OT  - Cisplatin eligibility
+OT  - Creatinine clearance
+OT  - Glomerular filtration rate
+OT  - Solitary kidney
+OT  - Transitional cell carcinoma
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2015/12/27 [received]
+PHST- 2016/04/18 [revised]
+PHST- 2016/04/22 [accepted]
+AID - S1558-7673(16)30108-2 [pii]
+AID - 10.1016/j.clgc.2016.04.018 [doi]
+PST - aheadofprint
+SO  - Clin Genitourin Cancer. 2016 May 2. pii: S1558-7673(16)30108-2. doi:
+      10.1016/j.clgc.2016.04.018.
+
+PMID- 27236751
+OWN - NLM
+STAT- Publisher
+DA  - 20160529
+LR  - 20160529
+IS  - 1525-3198 (Electronic)
+IS  - 0022-0302 (Linking)
+DP  - 2016 May 25
+TI  - The targeted proteins in tumor cells treated with the alpha-lactalbumin-oleic
+      acid complex examined by descriptive and quantitative liquid
+      chromatography-tandem mass spectrometry.
+LID - S0022-0302(16)30293-4 [pii]
+LID - 10.3168/jds.2016-10971 [doi]
+AB  - An alpha-lactalbumin-oleic acid (alpha-LA-OA) complex has exhibited selective
+      antitumor activity in animal models and clinical trials. Although apoptosis and
+      autophagy are activated and the functions of several organelles are disrupted in 
+      response to alpha-LA-OA, the detailed antitumor mechanism remains unclear. In
+      this study, we used a novel technique, isobaric tags for relative and absolute
+      quantitation, to analyze the proteome of tumor cells treated with alpha-LA-OA. We
+      identified 112 differentially expressed proteins: 95 were upregulated to satisfy 
+      the metabolism of tumor cells; 17 were downregulated and targets of alpha-LA-OA. 
+      According to the differentially expressed proteins, alpha-LA-OA exerted its
+      antitumor activity by disrupting cytoskeleton stability and cell motility, and by
+      inhibiting DNA, lipid, and adenosine triphosphate synthesis, leading to cellular 
+      stress and activation of programmed cell death. This study provides a systematic 
+      evaluation of the antitumor activity of alpha-LA-OA, identifying its interacting 
+      targets and establishing the theoretical basis of alpha-LA-OA for use in cancer
+      therapy.
+CI  - Copyright (c) 2016 American Dairy Science Association. Published by Elsevier Inc.
+      All rights reserved.
+FAU - Fang, B
+AU  - Fang B
+AD  - Beijing Advanced Innovation Center for Food Nutrition and Human Health, China
+      Agricultural University, Beijing, 100083, China. Electronic address:
+      49631263@qq.com.
+FAU - Zhang, M
+AU  - Zhang M
+AD  - Key Laboratory of Functional Dairy, College of Food Science and Nutritional
+      Engineering, China Agricultural University, Beijing, 100083, China; School of
+      Food Science and Chemical Engineering, Beijing Technology and Business
+      University, Beijing, 100048, China.
+FAU - Fan, X
+AU  - Fan X
+AD  - Beijing Laboratory for Food Quality and Safety, China Agricultural University,
+      Beijing, 100083, China.
+FAU - Ren, F Z
+AU  - Ren FZ
+AD  - Key Laboratory of Functional Dairy, College of Food Science and Nutritional
+      Engineering, China Agricultural University, Beijing, 100083, China; Beijing
+      Laboratory for Food Quality and Safety, China Agricultural University, Beijing,
+      100083, China.
+LA  - ENG
+PT  - JOURNAL ARTICLE
+DEP - 20160525
+TA  - J Dairy Sci
+JT  - Journal of dairy science
+JID - 2985126R
+OTO - NOTNLM
+OT  - antitumor
+OT  - human alpha-lactalbumin made lethal to tumor cells (HAMLET)
+OT  - isobaric tag for relative and absolute quantitation (iTRAQ)
+OT  - proteomics
+EDAT- 2016/05/30 06:00
+MHDA- 2016/05/30 06:00
+CRDT- 2016/05/30 06:00
+PHST- 2016/02/01 [received]
+PHST- 2016/04/14 [accepted]
+AID - S0022-0302(16)30293-4 [pii]
+AID - 10.3168/jds.2016-10971 [doi]
+PST - aheadofprint
+SO  - J Dairy Sci. 2016 May 25. pii: S0022-0302(16)30293-4. doi:
+      10.3168/jds.2016-10971.

--- a/test/parse-4.js
+++ b/test/parse-4.js
@@ -1,0 +1,60 @@
+var expect = require('chai').expect;
+var fs = require('fs');
+var rl = require('../index');
+
+/**
+ * This test (stupidly) sends an NBIB File to the XML parser which could happen if the client doesn't use .identify() 
+ * 	e.g. if the end-user wants to use Some-NBIB.txt and MyRIS.v2 files, we cannot trust the file ext.
+ * 	
+ * In v1.3.10, this causes a stack overflow in the error handler, due to the extra parser.end().
+ * The error wasn't caught, so would crash the application.
+ * I removed the extra parser.end() and added a try-catch around parser.write() which emits another error instead.
+ * 
+ * With the recursive parser.end() still in place, the try-catch around parser.write() does catch the stack-overflow
+ * but only when parsing a string data buffer. When parsing a filestream, the error is still thrown unhandled.
+ * 
+ * @author Pip Jones
+ */
+
+describe('EndNote XML parser - test #4 (incorrect file handling via data string)', function() {
+	var resErr = [];
+	var expectedErrors = 2;
+
+	before(function(next) {
+		this.timeout(60 * 1000);
+		data = fs.readFileSync(__dirname + '/data/medline-cancer.nbib');
+
+		rl.parse(data)
+		.on('error', function(err) {
+			resErr.push(err);
+			if(resErr.length === expectedErrors) next();
+		})
+	});
+	
+	it('should raise '+expectedErrors+' errors', function() {
+		expect(resErr).to.have.lengthOf(expectedErrors);
+		expect(resErr[0]).to.have.property('message').to.have.string('Non-whitespace before first tag.');
+		expect(resErr[1]).to.have.property('message').to.have.string('Text data outside of root node.');
+		// This error would happen instead if recursive parser.end() was left in the error handler
+		// expect(resErr[1]).to.have.property('message').to.have.string('Maximum call stack size exceeded'); 
+	});
+});
+
+describe('EndNote XML parser - test #4 (incorrect file handling via data-stream)', function() {
+	var resErr = [];
+	var expectedErrors = 1;
+
+	before(function(next) {
+		this.timeout(60 * 1000);
+		rl.parse(fs.createReadStream(__dirname + '/data/medline-cancer.nbib'))
+		.on('error', function(err) {
+			resErr.push(err);
+			if(resErr.length === expectedErrors) next();
+		})
+	});
+
+	it('should raise '+expectedErrors+' errors', function() {
+		expect(resErr).to.have.lengthOf(expectedErrors);
+		expect(resErr[0]).to.have.property('message').to.have.string('Non-whitespace before first tag.');
+	});
+});

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,17 +3,21 @@ var fs = require('fs');
 var rl = require('../index');
 
 describe('EndNote XML parser - bad XML', function() {
-	var resErr;
+	var resErr = [];
 	before(function(next) {
 		rl.parse('blah blah blah')
 			.on('error', function(err) {
-				resErr = err;
-				next();
+				// Two errors are raised: one more is sent after the internal parser.end() during first error
+				// the second is only emitted with an extra try-catch around parser.write(). 
+				resErr.push(err);
+				if(resErr.length === 2) next();
 			})
-			.on('end', next);
+			// 'end' doesn't get emitted after errors.
 	});
 
-	it('Should return an error', function() {
-		expect(resErr).to.be.ok;
+	it('Should return two errors', function() {
+		expect(resErr).to.have.lengthOf(2);
+		expect(resErr[0]).to.have.property('message').to.have.string('Non-whitespace before first tag.');
+		expect(resErr[1]).to.have.property('message').to.have.string('Text data outside of root node.');
 	});
 });


### PR DESCRIPTION
I've diagnosed a stack-overflow condition when importing a NBIB file into the EndnoteXML parser (user file mixup scenario).

I found there's two parts to the issue.

**Firstly** is the sometimes-recursive call to `parser.end()` in `reflib-endnotexml/index.js:131` during the error handler. While it tracks `hasErr` to prevent emitted more error events, it still tries to repeatedly stop the parser.

I can see why this might have been added. During my initial debugging I was intrigued to see the underlying parser continuing on after the first `parser.end()` call - I guessed it was something to do with the async-chain or some aspect of Sax which couldn't be arrested.

In the existing test `parse.js` this continuation is not noticed because the test ends too soon. After the first error, there's actually a second different one from Sax. I've adjusted that test to receive both.

In the case of a larger invalid data input (like the medline-cancer.nbib sampe), it seems Sax gets into a state where calling `parser.end()` itself causes an error, which in turn reflib catches, and so on.

This is an example the stack overflow (bottom up):
```
...
    at SAXStream.<anonymous> (index.js:131:12)
    at SAXParser.SAXStream._parser.onerror (node_modules/sax/lib/sax.js:194:10)
    at emit (node_modules/sax/lib/sax.js:624:35)
    at error (node_modules/sax/lib/sax.js:653:5)
    at end (node_modules/sax/lib/sax.js:662:7)
    at SAXParser.end (node_modules/sax/lib/sax.js:154:24)
    at SAXStream.end (node_modules/sax/lib/sax.js:248:18)
    at SAXStream.<anonymous> (index.js:131:12)
    at SAXParser.SAXStream._parser.onerror (node_modules/sax/lib/sax.js:194:10)
    at emit (node_modules/sax/lib/sax.js:624:35)
    at error (node_modules/sax/lib/sax.js:653:5)
    at end (node_modules/sax/lib/sax.js:662:7)
    at SAXParser.end (node_modules/sax/lib/sax.js:154:24)
    at SAXStream.end (node_modules/sax/lib/sax.js:248:18)
    at SAXStream.<anonymous> (index.js:131:12)
    at SAXParser.SAXStream._parser.onerror (node_modules/sax/lib/sax.js:194:10)
    at emit (node_modules/sax/lib/sax.js:624:35)
    at error (node_modules/sax/lib/sax.js:653:5)
    at strictFail (node_modules/sax/lib/sax.js:677:7)
    at SAXParser.write (node_modules/sax/lib/sax.js:1080:13)
    at SAXStream.write (node_modules/sax/lib/sax.js:239:18)
    at ReadStream.ondata (_stream_readable.js:646:20)
    at ReadStream.Readable.read (_stream_readable.js:482:10)
    at flow (_stream_readable.js:853:34)
    at resume_ (_stream_readable.js:835:3)
    at process._tickCallback (internal/process/next_tick.js:152:19)
```

So I propose removing the `parser.end()` call during repeat error handling - unless you know otherwise why it should be repeated.

**Secondly**, I looked into why the stack overflow was actually crashing Node and not being caught somewhere. While the top-level reflib.parse().on('error') catches most things, it wasn't catching the stack-overflow, and you can't add any other try-catches there due to the async nature of the internals.

After a bit of experiment I found (and this may be naive) that a try-catch block around the internal `parser.write(input).close()` around `index.js:206` does catch the stack-overflow and could be converted into an emitted error in line with the others.

Later I found this same try-catch also catches the second error which was missed by the `test/parse.js` - the 'Text data outside of root node.'. Presumably this was previously left as a hard-error but didn't crash the tests (because it had finished?)

Later I found, the error-handling behaviour is different depending on whether you pass a file-stream (like the existing tests) or a pre-loaded data string buffer (like in my app). This was confusing me until I figured out the difference. So I have added test variants for those scenarios in `test/parser-4`. 

So while I've proposed the general idea, I feel the try-catch is possibly not the right style? You may be able to change it to something equivalent in a more appropriate construct as you are more familiar with Sax and async-chainable. I looked at async-chainable for how you're supposed to catch errors, but it wasn't clear to me.

You may want to look again at the difference in Sax thrown errors between file-stream and string inputs, and large/small files which do or don't cause the more serious error state. I suspect I've still missed a case. 

BTW. I did try to leave the recursive `parser.end()` in and catch the overflow, but I found there was one impossible case. With a file-stream input, the stack-overflow error is thrown from within `parser.end()` in the error handler, but adding a try-catch there won't stop the runaway, it just silences the error and then you get an even more critical JS heap exhaustion error!

So I won't be offended if you reject the PR and ask me to implement it in a different way - if you can offer any guidance.

Hope that helps.

